### PR TITLE
Improve error handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "lint-js": "eslint *.js",
     "lint-cpp": "cpplint src/*",
     "lint": "npm run lint-js && npm run lint-cpp",
-    "test": "npm run lint && mocha tests -R spec"
+    "test": "npm run lint && mocha tests -R spec",
+    "install": "node-gyp rebuild"
   },
   "author": "Juan Cruz Viotti <juan@resin.io>",
   "license": "Apache-2.0",
@@ -40,5 +41,9 @@
   },
   "dependencies": {
     "bindings": "^1.2.1"
+  },
+  "gypfile": true,
+  "bugs": {
+    "url": "https://github.com/resin-io-modules/mountutils/issues"
   }
 }

--- a/src/functions_darwin.cpp
+++ b/src/functions_darwin.cpp
@@ -69,10 +69,14 @@ MOUNTUTILS_RESULT unmount_whole_disk(const char *device) {
 }
 
 NAN_METHOD(UnmountDisk) {
+  if (!info[1]->IsFunction()) {
+    return Nan::ThrowError("Callback must be a function");
+  }
+
   v8::Local<v8::Function> callback = info[1].As<v8::Function>();
 
   if (!info[0]->IsString()) {
-    YIELD_ERROR(callback, "Invalid device");
+    return Nan::ThrowError("Device argument must be a string");
   }
 
   v8::String::Utf8Value device(info[0]->ToString());

--- a/src/functions_linux.cpp
+++ b/src/functions_linux.cpp
@@ -20,10 +20,14 @@
 #include "utils.hpp"
 
 NAN_METHOD(UnmountDisk) {
+  if (!info[1]->IsFunction()) {
+    return Nan::ThrowError("Callback must be a function");
+  }
+
   v8::Local<v8::Function> callback = info[1].As<v8::Function>();
 
   if (!info[0]->IsString()) {
-    YIELD_ERROR(callback, "Invalid device");
+    return Nan::ThrowError("Device argument must be a string");
   }
 
   v8::String::Utf8Value device(info[0]->ToString());

--- a/src/functions_windows.cpp
+++ b/src/functions_windows.cpp
@@ -437,10 +437,14 @@ MOUNTUTILS_RESULT stringToInteger(char *string, int *out) {
 }
 
 NAN_METHOD(UnmountDisk) {
+  if (!info[1]->IsFunction()) {
+    return Nan::ThrowError("Callback must be a function");
+  }
+
   v8::Local<v8::Function> callback = info[1].As<v8::Function>();
 
   if (!info[0]->IsString()) {
-    YIELD_ERROR(callback, "Invalid device");
+    return Nan::ThrowError("Device argument must be a string");
   }
 
   v8::String::Utf8Value device(info[0]->ToString());

--- a/tests/mountutils.spec.js
+++ b/tests/mountutils.spec.js
@@ -25,6 +25,22 @@ describe('MountUtils', function() {
       chai.expect(mountutils.unmountDisk).to.be.a('function');
     });
 
+    context('missing / wrong arguments', function() {
+
+      specify('throws on missing device', function() {
+        chai.expect( function() {
+          mountutils.unmountDisk( null, function() {})
+        }).to.throw( /must be a string/i )
+      })
+
+      specify('throws on missing callback', function() {
+        chai.expect( function() {
+          mountutils.unmountDisk( 'novalue' )
+        }).to.throw( /must be a function/i )
+      })
+
+    })
+
   });
 
 });


### PR DESCRIPTION
This fixes crashes when invalid arguments would be supplied to the native binding by throwing proper errors if the argument types are wrong and also adds tests for those conditions.