### PR TITLE
feat(linux): Implement Linux support

### DIFF
--- a/src/linux/functions.cpp
+++ b/src/linux/functions.cpp
@@ -50,35 +50,39 @@ NAN_METHOD(UnmountDisk) {
     return;
   }
 
+  int result = -1;
+
   // TODO(jhermsmeier): Support únmounting multiple mountpoints (?)
   // NOTE: Might not be necessary, as MNT_DETACH will cause
   // every mount in the mount namespace to be lazily unmounted
   while ((mount_entity = getmntent(proc_mounts)) != NULL) {
-    mount_path = mount_entity->mnt_dir;
+    mount_path = mount_entity->mnt_fsname;
     if (strncmp(mount_path, device_path, strlen(device_path)) == 0) {
-      break;
+      // Use umount2() with the MNT_DETACH flag, which performs a lazy unmount;
+      // makíng the mount point unavailable for new accesses,
+      // and only actually unmounting when the mount point ceases to be busy
+      result = umount2(mount_entity->mnt_dir, MNT_DETACH);
+
+      // If unmounting fails, bail out
+      if (result != 0) {
+        endmntent(proc_mounts);
+        v8::Local<v8::Value> argv[1] = {
+          Nan::ErrnoException(errno, "umount2", NULL, mount_entity->mnt_dir)
+        };
+        v8::Local<v8::Object> ctx = Nan::GetCurrentContext()->Global();
+        Nan::MakeCallback(ctx, callback, 1, argv);
+        return;
+      }
     }
   }
 
   endmntent(proc_mounts);
 
-  if (mount_path == NULL) {
+  if (result == -1) {
     v8::Local<v8::Value> argv[1] = { Nan::Error("Couldn't find mount paths") };
     Nan::MakeCallback(Nan::GetCurrentContext()->Global(), callback, 1, argv);
     return;
   }
 
-  // Use umount2() with the MNT_DETACH flag, which performs a lazy unmount;
-  // makíng the mount point unavailable for new accesses,
-  // and only actually unmounting when the mount point ceases to be busy
-  int result = umount2(mount_path, MNT_DETACH);
-
-  if (result == 0) {
-    Nan::MakeCallback(Nan::GetCurrentContext()->Global(), callback, 0, 0);
-  } else {
-    v8::Local<v8::Value> argv[1] = {
-      Nan::ErrnoException(errno, "umount", NULL, mount_path)
-    };
-    Nan::MakeCallback(Nan::GetCurrentContext()->Global(), callback, 1, argv);
-  }
+  Nan::MakeCallback(Nan::GetCurrentContext()->Global(), callback, 0, 0);
 }

--- a/src/linux/functions.cpp
+++ b/src/linux/functions.cpp
@@ -90,11 +90,5 @@ NAN_METHOD(UnmountDisk) {
 
   endmntent(proc_mounts);
 
-  if (result == -1) {
-    v8::Local<v8::Value> argv[1] = { Nan::Error("Couldn't find mount paths") };
-    Nan::MakeCallback(Nan::GetCurrentContext()->Global(), callback, 1, argv);
-    return;
-  }
-
   Nan::MakeCallback(Nan::GetCurrentContext()->Global(), callback, 0, 0);
 }

--- a/src/linux/functions.cpp
+++ b/src/linux/functions.cpp
@@ -45,6 +45,12 @@ NAN_METHOD(UnmountDisk) {
     };
     Nan::MakeCallback(Nan::GetCurrentContext()->Global(), callback, 1, argv);
     return;
+  } else if (S_ISDIR(stats.st_mode)) {
+    v8::Local<v8::Value> argv[1] = {
+      Nan::Error("Invalid device, path is a directory")
+    };
+    Nan::MakeCallback(Nan::GetCurrentContext()->Global(), callback, 1, argv);
+    return;
   }
 
   // Get mountpaths from the device path, as `umount(device)`


### PR DESCRIPTION
This implements unounting of devices in Linux, specifically the `.unmountDisk()` method.

**TODO:**
- [x] ~~Split out getting the mountpath into another function~~
- [x] Test whether `MNT_DETACH` successfully unmounts a device with multiple mountpaths