### PR TITLE
Windows: fix "invalid drive" errors on Windows 7

### DIFF
--- a/src/windows/functions.cpp
+++ b/src/windows/functions.cpp
@@ -390,6 +390,14 @@ MOUNTUTILS_RESULT Eject(ULONG deviceNumber) {
         // which gets fixed if you retry again.
         for (size_t times = 0; times < 3; times++) {
           result = EjectDriveLetter(currentDriveLetter);
+
+          // Abort the loop if we couldn't open a handle on the drive letter
+          // after previous attempts worked, since this means the drive was
+          // completely ejected, and that we don't have to keep retrying.
+          if (times > 0 && result == MOUNTUTILS_ERROR_INVALID_DRIVE) {
+            break;
+          }
+
           if (result != MOUNTUTILS_SUCCESS) {
             return result;
           }


### PR DESCRIPTION
We can't open a handle on an ejected drive letter on Windows 7, which
means that our `EjectDriveLetter` safety retry look causes the program
to fail with an error even though the drive was unmounted correctly.

As a solution, we abort the loop if previous tries succeeded and we get
`MOUNTUTILS_ERROR_INVALID_DRIVE` (which means we couldn't open a handle
on the drive).

This error only happens on Windows 7, and I only experienced it on
internal SD Card readers and external HDDs.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>