### PR TITLE
refactor(linux): Clean up comments, remove unused var

### DIFF
--- a/src/linux/functions.cpp
+++ b/src/linux/functions.cpp
@@ -68,21 +68,13 @@ NAN_METHOD(UnmountDisk) {
     return;
   }
 
-  int result = -1;
-
-  // TODO(jhermsmeier): Support únmounting multiple mountpoints (?)
-  // NOTE: Might not be necessary, as MNT_DETACH will cause
-  // every mount in the mount namespace to be lazily unmounted
   while ((mount_entity = getmntent(proc_mounts)) != NULL) {
     mount_path = mount_entity->mnt_fsname;
     if (strncmp(mount_path, device_path, strlen(device_path)) == 0) {
       // Use umount2() with the MNT_DETACH flag, which performs a lazy unmount;
-      // makíng the mount point unavailable for new accesses,
+      // making the mount point unavailable for new accesses,
       // and only actually unmounting when the mount point ceases to be busy
-      result = umount2(mount_entity->mnt_dir, MNT_DETACH);
-
-      // If unmounting fails, bail out
-      if (result != 0) {
+      if (umount2(mount_entity->mnt_dir, MNT_DETACH) != 0) {
         endmntent(proc_mounts);
         v8::Local<v8::Value> argv[1] = {
           Nan::ErrnoException(errno, "umount2", NULL, mount_entity->mnt_dir)


### PR DESCRIPTION
Remove an out-of-date comment that slipped in, fix accented characters in comments (again), and remove the now unnecessary `int result`

Connects to #10