### PR TITLE
Don't use wildcards at binding.gyp

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -10,14 +10,14 @@
         [ 'OS=="linux"', {
           "sources": [
             "src/mountutils.cpp",
-            "src/linux/*.cpp"
+            "src/linux/functions.cpp"
           ],
         } ],
 
         [ 'OS=="win"', {
           "sources": [
             "src/mountutils.cpp",
-            "src/windows/*.cpp"
+            "src/windows/functions.cpp"
           ],
           "libraries": [
             "-luser32.lib",
@@ -28,7 +28,7 @@
         [ 'OS=="mac"', {
           "sources": [
             "src/mountutils.cpp",
-            "src/darwin/*.cpp"
+            "src/darwin/functions.cpp"
           ],
           "link_settings": {
             "libraries": [


### PR DESCRIPTION
This is causing errors on Appveyor when installing this module from npm.

See: https://ci.appveyor.com/project/resin-io/etcher/build/1.0.2975/job/qfho1hp3yvc9m7tm
See: https://ci.appveyor.com/project/resin-io/etcher/build/1.0.2976/job/8h2ruf070c9mh3a9
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>