### PR TITLE
Make `nan` a production dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,11 +36,11 @@
     "eslint": "^3.17.1",
     "jsdoc-to-markdown": "^3.0.0",
     "mocha": "^3.2.0",
-    "nan": "^2.5.1",
     "node-gyp": "^3.5.0"
   },
   "dependencies": {
-    "bindings": "^1.2.1"
+    "bindings": "^1.2.1",
+    "nan": "^2.5.1"
   },
   "gypfile": true,
   "bugs": {


### PR DESCRIPTION
The `nan` project examples recommend having it as a production
development. Currently, Windows builds from npm fail because of this:

```
C:\Projects\playground\mountutils-test\node_modules\mountutils>if not defined npm_config_node_gyp (node "C:\Users\jviotti\AppData\Roaming\npm\node_modules\npm\bin\node-gyp-bin\\..\..\node_modules\node-gyp\bin\node-gyp.js" rebuild )  else (node "" rebuild )
module.js:440
    throw err;
    ^
Error: Cannot find module 'nan'
    at Function.Module._resolveFilename (module.js:438:15)
    at Function.Module._load (module.js:386:25)
    at Module.require (module.js:466:17)
    at require (internal/module.js:20:19)
    at [eval]:1:1
    at Object.exports.runInThisContext (vm.js:54:17)
    at Object.<anonymous> ([eval]-wrapper:6:22)
    at Module._compile (module.js:541:32)
    at node.js:329:29
    at _combinedTickCallback (internal/process/next_tick.js:67:7)
gyp: Call to 'node -e "require('nan')"' returned exit status 1 while in binding.gyp. while trying to load binding.gyp
```

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>