### PR TITLE
Set the bindings module root to __dirname

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,4 +49,13 @@
  * });
  */
 
-module.exports = require('bindings')('MountUtils');
+module.exports = require('bindings')({
+  bindings: 'MountUtils',
+
+/* eslint-disable camelcase */
+
+  module_root: __dirname
+
+/* eslint-enable camelcase */
+
+});


### PR DESCRIPTION
The `bindings` module gets the module root by using `path.dirname()`
over the filename inferred from v8's error API, which means the path is
not resolved correctly on Browserify, which is smart enough to recognise
`__dirname` and `__filename`, and ensure they get resolved correctly on
the final bundle.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>