### PR TITLE
Fix "Unmount failed" error on Windows

### DIFF
--- a/src/windows/functions.cpp
+++ b/src/windows/functions.cpp
@@ -393,6 +393,38 @@ MOUNTUTILS_RESULT EjectDriveLetter(TCHAR driveLetter) {
   return MOUNTUTILS_SUCCESS;
 }
 
+BOOL IsDriveEjectable(TCHAR driveLetter) {
+  TCHAR devicePath[8];
+  wsprintf(devicePath, TEXT("%c:\\"), driveLetter);
+
+  MountUtilsLog("Checking whether drive is ejectable: "
+      + std::string(1, driveLetter));
+
+  switch (GetDriveType(devicePath)) {
+    case DRIVE_NO_ROOT_DIR:
+      MountUtilsLog("The drive doesn't exist");
+      return FALSE;
+    case DRIVE_REMOVABLE:
+      MountUtilsLog("The drive is removable");
+      return TRUE;
+    case DRIVE_FIXED:
+      MountUtilsLog("The drive is fixed");
+      return TRUE;
+    case DRIVE_REMOTE:
+      MountUtilsLog("The drive is remote");
+      return FALSE;
+    case DRIVE_CDROM:
+      MountUtilsLog("The drive is a CDROM");
+      return FALSE;
+    case DRIVE_RAMDISK:
+      MountUtilsLog("The drive is a RAM disk");
+      return FALSE;
+    default:
+      MountUtilsLog("The drive type is unknown");
+      return FALSE;
+  }
+}
+
 MOUNTUTILS_RESULT Eject(ULONG deviceNumber) {
   DWORD logicalDrivesMask = GetLogicalDrives();
   TCHAR currentDriveLetter = 'A';
@@ -403,7 +435,7 @@ MOUNTUTILS_RESULT Eject(ULONG deviceNumber) {
   }
 
   while (logicalDrivesMask) {
-    if (logicalDrivesMask & 1) {
+    if (logicalDrivesMask & 1 && IsDriveEjectable(currentDriveLetter)) {
       MountUtilsLog("Opening drive letter handle: "
           + std::string(1, currentDriveLetter));
 


### PR DESCRIPTION
We've been recently seeing tons of "Unmount failed" errors coming from
Windows. After some inspection, all the debugging stack traces show the
following scenario:

- X drive letters are scanned, but none belongs to the drive we're
  trying to unmount
- Finally, one of the drive letter matches
- The matching drive letter is successfully unmounted
- We continue scanning more drive letters
- We get an invalid handle error when opening such drive letter

This issue happens when the computer mounts network drive letters (which
get usually mounted using letters like X, and Z). The code sees that
such as drive letter exists, and tries to open a handle for it, which
fails with an invalid handle error.

There is another edge case where we've seen this bug.

Note that we get a list of logical drives once mountutils start, and we
keep it on memory in order to refer to it as we traverse through the
available drive letters.

If we scan than drive F: is available for example, we don't have any
guarantee that such drive letter is still available by the time we're
interacting with it (which is made worse by the fact we have retry
timeouts in some parts of the code).

This issue can be reproduced by plugging two drives, ejecting the drive
letter that comes first, and quickly removing the other drive while the
selected drive is being unmounted.

As a solution, we re-check that the drive letter is valid every time
we're about to access it.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>