### PR TITLE
fix(windows): Replace use of `wsprintf()`

### DIFF
--- a/src/windows/functions.cpp
+++ b/src/windows/functions.cpp
@@ -40,7 +40,7 @@ HANDLE CreateVolumeHandleFromDevicePath(LPCTSTR devicePath, DWORD flags) {
 
 HANDLE CreateVolumeHandleFromDriveLetter(TCHAR driveLetter, DWORD flags) {
   TCHAR devicePath[8];
-  wsprintf(devicePath, TEXT("\\\\.\\%c:"), driveLetter);
+  sprintf_s(devicePath, "\\\\.\\%c:", driveLetter);
   return CreateVolumeHandleFromDevicePath(devicePath, flags);
 }
 
@@ -65,7 +65,7 @@ ULONG GetDeviceNumberFromVolumeHandle(HANDLE volume) {
 
 BOOL IsDriveFixed(TCHAR driveLetter) {
   TCHAR rootName[5];
-  wsprintf(rootName, TEXT("%c:\\"), driveLetter);
+  sprintf_s(rootName, "%c:\\", driveLetter);
   return GetDriveType(rootName) == DRIVE_FIXED;
 }
 
@@ -395,7 +395,7 @@ MOUNTUTILS_RESULT EjectDriveLetter(TCHAR driveLetter) {
 
 BOOL IsDriveEjectable(TCHAR driveLetter) {
   TCHAR devicePath[8];
-  wsprintf(devicePath, TEXT("%c:\\"), driveLetter);
+  sprintf_s(devicePath, "%c:\\", driveLetter);
 
   MountUtilsLog("Checking whether drive is ejectable: "
       + std::string(1, driveLetter));


### PR DESCRIPTION
Due to security considerations, this replaces [wsprintf()] with [sprintf_s()].
See https://msdn.microsoft.com/en-us/library/windows/desktop/ms647550(v=vs.85).aspx

[wsprintf()]: https://msdn.microsoft.com/en-us/library/windows/desktop/ms647550(v=vs.85).aspx
[sprintf_s()]: https://msdn.microsoft.com/en-us/library/ce3zzk1k.aspx

Change-Type: patch
Connects To: #28 