### PR TITLE
feat: Implement .eject() method

### DIFF
--- a/example/eject.js
+++ b/example/eject.js
@@ -23,13 +23,13 @@ let argv = process.argv.slice(2);
 let disk = argv.shift();
 
 if (!disk) {
-  console.error(`Usage: node scripts/eject ${process.argv[1]} <drive>`);
+  console.error(`Usage: node example/eject <disk>`);
   process.exit(1);
 }
 
 process.env.MOUNTUTILS_DEBUG = true;
 
-console.log('Ejecting', disk, '...')
+console.log('Ejecting', disk, '...');
 
 mountUtils.eject(disk, function(error) {
   console.log(error || 'OK');

--- a/example/eject.js
+++ b/example/eject.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 /*
  * Copyright 2017 resin.io
  *
@@ -16,20 +17,20 @@
 
 'use strict';
 
-const mountutils = require('.');
-const drive = process.argv[2];
+const mountUtils = require('..');
 
-if (!drive) {
-  console.error(`Usage: ${process.argv[0]} ${process.argv[1]} <drive>`);
+let argv = process.argv.slice(2);
+let disk = argv.shift();
+
+if (!disk) {
+  console.error(`Usage: node scripts/eject ${process.argv[1]} <drive>`);
   process.exit(1);
 }
 
-console.log(`Unmounting ${drive}`);
+process.env.MOUNTUTILS_DEBUG = true;
 
-mountutils.unmountDisk(drive, (error) => {
-  if (error) {
-    throw error;
-  }
+console.log('Ejecting', disk, '...')
 
-  console.log('Done');
+mountUtils.eject(disk, function(error) {
+  console.log(error || 'OK');
 });

--- a/example/unmount.js
+++ b/example/unmount.js
@@ -23,13 +23,13 @@ let argv = process.argv.slice(2);
 let disk = argv.shift();
 
 if (!disk) {
-  console.error(`Usage: node scripts/unmount ${process.argv[1]} <drive>`);
+  console.error(`Usage: node example/unmount <disk>`);
   process.exit(1);
 }
 
 process.env.MOUNTUTILS_DEBUG = true;
 
-console.log('Ejecting', disk, '...')
+console.log('Unmounting', disk, '...');
 
 mountUtils.unmountDisk(disk, function(error) {
   console.log(error || 'OK');

--- a/example/unmount.js
+++ b/example/unmount.js
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+/*
+ * Copyright 2017 resin.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const mountUtils = require('..');
+
+let argv = process.argv.slice(2);
+let disk = argv.shift();
+
+if (!disk) {
+  console.error(`Usage: node scripts/unmount ${process.argv[1]} <drive>`);
+  process.exit(1);
+}
+
+process.env.MOUNTUTILS_DEBUG = true;
+
+console.log('Ejecting', disk, '...')
+
+mountUtils.unmountDisk(disk, function(error) {
+  console.log(error || 'OK');
+});

--- a/src/darwin/functions.cpp
+++ b/src/darwin/functions.cpp
@@ -122,8 +122,7 @@ MOUNTUTILS_RESULT eject_disk(const char* device) {
     return MOUNTUTILS_ERROR_GENERAL;
   }
 
-  // NOTE: Don't do this if you already have a
-  // running Core Foundation or Cocoa run loop
+  // Get a reference to the current thread's runloop
   CFRunLoopRef run_loop = CFRunLoopGetCurrent();
 
   // Get a disk object from the disk path

--- a/src/linux/functions.cpp
+++ b/src/linux/functions.cpp
@@ -20,20 +20,7 @@
 #include <errno.h>
 #include "../mountutils.hpp"
 
-NAN_METHOD(UnmountDisk) {
-  if (!info[1]->IsFunction()) {
-    return Nan::ThrowTypeError("Callback must be a function");
-  }
-
-  v8::Local<v8::Function> callback = info[1].As<v8::Function>();
-
-  if (!info[0]->IsString()) {
-    return Nan::ThrowTypeError("Device argument must be a string");
-  }
-
-  v8::String::Utf8Value device(info[0]->ToString());
-
-  const char *device_path = reinterpret_cast<char *>(*device);
+void unmount_disk(const char *device_path, v8::Local<v8::Function> callback) {
   const char *mount_path = NULL;
 
   // Stat the device to make sure it exists
@@ -104,4 +91,38 @@ NAN_METHOD(UnmountDisk) {
   endmntent(proc_mounts);
 
   Nan::MakeCallback(Nan::GetCurrentContext()->Global(), callback, 0, 0);
+}
+
+NAN_METHOD(UnmountDisk) {
+  if (!info[1]->IsFunction()) {
+    return Nan::ThrowTypeError("Callback must be a function");
+  }
+
+  v8::Local<v8::Function> callback = info[1].As<v8::Function>();
+
+  if (!info[0]->IsString()) {
+    return Nan::ThrowTypeError("Device argument must be a string");
+  }
+
+  v8::String::Utf8Value device(info[0]->ToString());
+
+  unmount_disk(reinterpret_cast<char *>(*device));
+}
+
+// FIXME: This is just a stub copy of `UnmountDisk()`,
+// and needs implementation!
+NAN_METHOD(EjectDisk) {
+  if (!info[1]->IsFunction()) {
+    return Nan::ThrowTypeError("Callback must be a function");
+  }
+
+  v8::Local<v8::Function> callback = info[1].As<v8::Function>();
+
+  if (!info[0]->IsString()) {
+    return Nan::ThrowTypeError("Device argument must be a string");
+  }
+
+  v8::String::Utf8Value device(info[0]->ToString());
+
+  unmount_disk(reinterpret_cast<char *>(*device));
 }

--- a/src/linux/functions.cpp
+++ b/src/linux/functions.cpp
@@ -106,7 +106,7 @@ NAN_METHOD(UnmountDisk) {
 
   v8::String::Utf8Value device(info[0]->ToString());
 
-  unmount_disk(reinterpret_cast<char *>(*device));
+  unmount_disk(reinterpret_cast<char *>(*device), callback);
 }
 
 // FIXME: This is just a stub copy of `UnmountDisk()`,
@@ -124,5 +124,5 @@ NAN_METHOD(EjectDisk) {
 
   v8::String::Utf8Value device(info[0]->ToString());
 
-  unmount_disk(reinterpret_cast<char *>(*device));
+  unmount_disk(reinterpret_cast<char *>(*device), callback);
 }

--- a/src/mountutils.cpp
+++ b/src/mountutils.cpp
@@ -22,6 +22,10 @@ NAN_MODULE_INIT(MountUtilsInit) {
   Nan::Set(target, Nan::New("unmountDisk").ToLocalChecked(),
     Nan::GetFunction(Nan::New<v8::FunctionTemplate>(UnmountDisk))
   .ToLocalChecked());
+
+  Nan::Set(target, Nan::New("eject").ToLocalChecked(),
+    Nan::GetFunction(Nan::New<v8::FunctionTemplate>(EjectDisk))
+  .ToLocalChecked());
 }
 
 

--- a/src/mountutils.hpp
+++ b/src/mountutils.hpp
@@ -38,5 +38,6 @@ enum MOUNTUTILS_RESULT {
 void MountUtilsLog(std::string string);
 
 NAN_METHOD(UnmountDisk);
+NAN_METHOD(EjectDisk);
 
 #endif  // SRC_MOUNTUTILS_HPP_

--- a/src/windows/functions.cpp
+++ b/src/windows/functions.cpp
@@ -553,3 +553,39 @@ NAN_METHOD(UnmountDisk) {
     YIELD_ERROR(callback, "Unmount failed");
   }
 }
+
+// FIXME: This is just a stub copy of `UnmountDisk()`,
+// and needs implementation!
+NAN_METHOD(EjectDisk) {
+  if (!info[1]->IsFunction()) {
+    return Nan::ThrowError("Callback must be a function");
+  }
+
+  v8::Local<v8::Function> callback = info[1].As<v8::Function>();
+
+  if (!info[0]->IsString()) {
+    return Nan::ThrowError("Device argument must be a string");
+  }
+
+  v8::String::Utf8Value device(info[0]->ToString());
+
+  // Get the ID of a \\\\.\\PHYSICALDRIVEN path
+  char *deviceString = reinterpret_cast<char *>(*device);
+  char *deviceIdString = &deviceString[strlen(deviceString) - 1];
+  int deviceId;
+  if (stringToInteger(deviceIdString, &deviceId) != MOUNTUTILS_SUCCESS) {
+    YIELD_ERROR(callback, "Invalid device");
+  }
+
+  MOUNTUTILS_RESULT result = Eject(deviceId);
+
+  if (result == MOUNTUTILS_SUCCESS) {
+    YIELD_NOTHING(callback);
+  } else if (result == MOUNTUTILS_ERROR_ACCESS_DENIED) {
+    YIELD_ERROR(callback, "Unmount failed, access denied");
+  } else if (result == MOUNTUTILS_ERROR_INVALID_DRIVE) {
+    YIELD_ERROR(callback, "Unmount failed, invalid drive");
+  } else {
+    YIELD_ERROR(callback, "Unmount failed");
+  }
+}

--- a/tests/mountutils.spec.js
+++ b/tests/mountutils.spec.js
@@ -43,4 +43,28 @@ describe('MountUtils', function() {
 
   });
 
+  describe('.eject()', function() {
+
+    it('should be a function', function() {
+      chai.expect(mountutils.eject).to.be.a('function');
+    });
+
+    context('missing / wrong arguments', function() {
+
+      specify('throws on missing device', function() {
+        chai.expect( function() {
+          mountutils.eject( null, function() {})
+        }).to.throw( /must be a string/i )
+      })
+
+      specify('throws on missing callback', function() {
+        chai.expect( function() {
+          mountutils.eject( 'novalue' )
+        }).to.throw( /must be a function/i )
+      })
+
+    })
+
+  });
+
 });


### PR DESCRIPTION
This implements an `.eject()` method, to both unmount & eject a device from a system.

**NOTE:** This is currently only implemented for Mac OS, with Linux & Windows methods stubbed to `.unmountDisk()`, until those implementations can be backfilled.

Connects To: https://github.com/resin-io/etcher/issues/1385