### PR TITLE
chore(travis): Use clang-4.0, remove sudo setting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: node_js
-sudo: false
 node_js:
   - 6
 os:
@@ -13,7 +12,7 @@ before_install:
     fi
 script:
   - npm test
-compiler: clang-3.6
+compiler: clang-4.0
 env:
   global:
     - CCACHE_TEMPDIR=/tmp/.ccache-temp


### PR DESCRIPTION
This updates the used compiler from `clang-3.6` to `clang-4.0`
and also removes the `sudo: false` setting, as it's the default now.

Change-Type: patch