### PR TITLE
chore(npmignore): Exclude .yml files from package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,6 +2,7 @@
 .*
 *.md
 *.log
+*.yml
 
 # Directories
 doc


### PR DESCRIPTION
This excludes the `.yml` CI config file from being bundled
in the npm package.

Change-Type: patch