### PR TITLE
feat(src): Use Nan::AsyncWorker

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -5,18 +5,19 @@
       "include_dirs" : [
         "<!(node -e \"require('nan')\")"
       ],
+      "sources": [
+        "src/mountutils.cpp"
+      ],
       'conditions': [
 
         [ 'OS=="linux"', {
           "sources": [
-            "src/mountutils.cpp",
             "src/linux/functions.cpp"
           ],
         } ],
 
         [ 'OS=="win"', {
           "sources": [
-            "src/mountutils.cpp",
             "src/windows/functions.cpp"
           ],
           "libraries": [
@@ -27,7 +28,6 @@
 
         [ 'OS=="mac"', {
           "sources": [
-            "src/mountutils.cpp",
             "src/darwin/functions.cpp"
           ],
           "link_settings": {

--- a/binding.gyp
+++ b/binding.gyp
@@ -6,7 +6,9 @@
         "<!(node -e \"require('nan')\")"
       ],
       "sources": [
-        "src/mountutils.cpp"
+        "src/mountutils.cpp",
+        "src/worker-unmount.cpp",
+        "src/worker-eject.cpp"
       ],
       'conditions': [
 

--- a/src/darwin/functions.cpp
+++ b/src/darwin/functions.cpp
@@ -170,7 +170,7 @@ MOUNTUTILS_RESULT eject_disk(const char* device) {
   return run_cb(device, _eject_unmount_cb);
 }
 
-NAN_METHOD(UnmountDisk) {
+NAN_METHOD(unmountDisk) {
   if (!info[1]->IsFunction()) {
     return Nan::ThrowError("Callback must be a function");
   }
@@ -199,7 +199,7 @@ NAN_METHOD(UnmountDisk) {
   }
 }
 
-NAN_METHOD(EjectDisk) {
+NAN_METHOD(eject) {
   if (!info[1]->IsFunction()) {
     return Nan::ThrowError("Callback must be a function");
   }

--- a/src/darwin/functions.cpp
+++ b/src/darwin/functions.cpp
@@ -162,66 +162,10 @@ void _eject_unmount_cb(DADiskRef disk, DADissenterRef dissenter, void *ctx) {
   }
 }
 
-MOUNTUTILS_RESULT unmount_whole_disk(const char* device) {
+MOUNTUTILS_RESULT unmount_disk(const char* device) {
   return run_cb(device, _unmount_cb);
 }
 
 MOUNTUTILS_RESULT eject_disk(const char* device) {
   return run_cb(device, _eject_unmount_cb);
-}
-
-NAN_METHOD(unmountDisk) {
-  if (!info[1]->IsFunction()) {
-    return Nan::ThrowError("Callback must be a function");
-  }
-
-  v8::Local<v8::Function> callback = info[1].As<v8::Function>();
-
-  if (!info[0]->IsString()) {
-    return Nan::ThrowError("Device argument must be a string");
-  }
-
-  v8::String::Utf8Value device(info[0]->ToString());
-
-  MOUNTUTILS_RESULT result =
-    unmount_whole_disk(reinterpret_cast<char *>(*device));
-
-  MountUtilsLog("Unmount complete");
-
-  if (result == MOUNTUTILS_SUCCESS) {
-    YIELD_NOTHING(callback);
-  } else if (result == MOUNTUTILS_ERROR_ACCESS_DENIED) {
-    YIELD_ERROR(callback, "Unmount failed, access denied");
-  } else if (result == MOUNTUTILS_ERROR_INVALID_DRIVE) {
-    YIELD_ERROR(callback, "Unmount failed, invalid drive");
-  } else {
-    YIELD_ERROR(callback, "Unmount failed");
-  }
-}
-
-NAN_METHOD(eject) {
-  if (!info[1]->IsFunction()) {
-    return Nan::ThrowError("Callback must be a function");
-  }
-
-  v8::Local<v8::Function> callback = info[1].As<v8::Function>();
-
-  if (!info[0]->IsString()) {
-    return Nan::ThrowError("Device argument must be a string");
-  }
-
-  v8::String::Utf8Value device(info[0]->ToString());
-
-  MOUNTUTILS_RESULT result =
-    eject_disk(reinterpret_cast<char *>(*device));
-
-  if (result == MOUNTUTILS_SUCCESS) {
-    YIELD_NOTHING(callback);
-  } else if (result == MOUNTUTILS_ERROR_ACCESS_DENIED) {
-    YIELD_ERROR(callback, "Unmount failed, access denied");
-  } else if (result == MOUNTUTILS_ERROR_INVALID_DRIVE) {
-    YIELD_ERROR(callback, "Unmount failed, invalid drive");
-  } else {
-    YIELD_ERROR(callback, "Unmount failed");
-  }
 }

--- a/src/linux/functions.cpp
+++ b/src/linux/functions.cpp
@@ -93,7 +93,7 @@ void unmount_disk(const char *device_path, v8::Local<v8::Function> callback) {
   Nan::MakeCallback(Nan::GetCurrentContext()->Global(), callback, 0, 0);
 }
 
-NAN_METHOD(UnmountDisk) {
+NAN_METHOD(unmountDisk) {
   if (!info[1]->IsFunction()) {
     return Nan::ThrowTypeError("Callback must be a function");
   }
@@ -111,7 +111,7 @@ NAN_METHOD(UnmountDisk) {
 
 // FIXME: This is just a stub copy of `UnmountDisk()`,
 // and needs implementation!
-NAN_METHOD(EjectDisk) {
+NAN_METHOD(eject) {
   if (!info[1]->IsFunction()) {
     return Nan::ThrowTypeError("Callback must be a function");
   }

--- a/src/mountutils.cpp
+++ b/src/mountutils.cpp
@@ -19,15 +19,9 @@
 #include "mountutils.hpp"
 
 NAN_MODULE_INIT(MountUtilsInit) {
-  Nan::Set(target, Nan::New("unmountDisk").ToLocalChecked(),
-    Nan::GetFunction(Nan::New<v8::FunctionTemplate>(UnmountDisk))
-  .ToLocalChecked());
-
-  Nan::Set(target, Nan::New("eject").ToLocalChecked(),
-    Nan::GetFunction(Nan::New<v8::FunctionTemplate>(EjectDisk))
-  .ToLocalChecked());
+  NAN_EXPORT(target, unmountDisk);
+  NAN_EXPORT(target, eject);
 }
-
 
 void MountUtilsLog(std::string string) {
   const char* debug = std::getenv("MOUNTUTILS_DEBUG");

--- a/src/mountutils.hpp
+++ b/src/mountutils.hpp
@@ -20,14 +20,6 @@
 #include <nan.h>
 #include <string>
 
-#define YIELD_ERROR(CALLBACK, ERROR) \
-  v8::Local<v8::Value> argv[1] = { Nan::Error((ERROR)) }; \
-  Nan::MakeCallback(Nan::GetCurrentContext()->Global(), (CALLBACK), 1, argv); \
-  return;
-
-#define YIELD_NOTHING(CALLBACK) \
-  Nan::MakeCallback(Nan::GetCurrentContext()->Global(), (CALLBACK), 0, 0);
-
 enum MOUNTUTILS_RESULT {
   MOUNTUTILS_SUCCESS,
   MOUNTUTILS_ERROR_INVALID_DRIVE,
@@ -36,6 +28,9 @@ enum MOUNTUTILS_RESULT {
 };
 
 void MountUtilsLog(std::string string);
+
+MOUNTUTILS_RESULT unmount_disk(const char *device);
+MOUNTUTILS_RESULT eject_disk(const char *device);
 
 NAN_METHOD(unmountDisk);
 NAN_METHOD(eject);

--- a/src/mountutils.hpp
+++ b/src/mountutils.hpp
@@ -37,7 +37,7 @@ enum MOUNTUTILS_RESULT {
 
 void MountUtilsLog(std::string string);
 
-NAN_METHOD(UnmountDisk);
-NAN_METHOD(EjectDisk);
+NAN_METHOD(unmountDisk);
+NAN_METHOD(eject);
 
 #endif  // SRC_MOUNTUTILS_HPP_

--- a/src/windows/functions.cpp
+++ b/src/windows/functions.cpp
@@ -520,7 +520,7 @@ MOUNTUTILS_RESULT stringToInteger(char *string, int *out) {
   return MOUNTUTILS_SUCCESS;
 }
 
-NAN_METHOD(UnmountDisk) {
+NAN_METHOD(unmountDisk) {
   if (!info[1]->IsFunction()) {
     return Nan::ThrowError("Callback must be a function");
   }
@@ -556,7 +556,7 @@ NAN_METHOD(UnmountDisk) {
 
 // FIXME: This is just a stub copy of `UnmountDisk()`,
 // and needs implementation!
-NAN_METHOD(EjectDisk) {
+NAN_METHOD(eject) {
   if (!info[1]->IsFunction()) {
     return Nan::ThrowError("Callback must be a function");
   }

--- a/src/worker-eject.cpp
+++ b/src/worker-eject.cpp
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2017 resin.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <nan.h>
+#include "mountutils.hpp"
+
+class EjectWorker : public Nan::AsyncWorker {
+ public:
+  EjectWorker(Nan::Callback *callback, std::string device)
+    : Nan::AsyncWorker(callback) {
+    device_path = device;
+  }
+
+  ~EjectWorker() {}
+
+  void Execute() {
+    MOUNTUTILS_RESULT result = eject_disk(device_path.c_str());
+
+    MountUtilsLog("Eject complete");
+
+    if (result != MOUNTUTILS_SUCCESS) {
+      switch (result) {
+        case MOUNTUTILS_ERROR_ACCESS_DENIED:
+          SetErrorMessage("Eject failed, access denied");
+          break;
+        case MOUNTUTILS_ERROR_INVALID_DRIVE:
+          SetErrorMessage("Eject failed, invalid drive");
+          break;
+        default:
+          SetErrorMessage("Eject failed");
+          break;
+      }
+    }
+  }
+
+  void HandleOKCallback() {
+    Nan::HandleScope scope;
+    v8::Local<v8::Value> argv[] = { Nan::Null() };
+    callback->Call(1, argv);
+  }
+
+ private:
+  std::string device_path;
+};
+
+NAN_METHOD(eject) {
+  if (!info[1]->IsFunction()) {
+    return Nan::ThrowError("Callback must be a function");
+  }
+
+  if (!info[0]->IsString()) {
+    return Nan::ThrowError("Device must be a string");
+  }
+
+  Nan::Utf8String device(info[0]->ToString());
+  std::string device_path(*device);
+  Nan::Callback *callback = new Nan::Callback(info[1].As<v8::Function>());
+
+  Nan::AsyncQueueWorker(new EjectWorker(callback, device_path));
+
+  info.GetReturnValue().SetUndefined();
+}

--- a/src/worker-unmount.cpp
+++ b/src/worker-unmount.cpp
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2017 resin.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <nan.h>
+#include "mountutils.hpp"
+
+class UnmountWorker : public Nan::AsyncWorker {
+ public:
+  UnmountWorker(Nan::Callback *callback, std::string device)
+    : Nan::AsyncWorker(callback) {
+    device_path = device;
+  }
+
+  ~UnmountWorker() {}
+
+  void Execute() {
+    MOUNTUTILS_RESULT result = unmount_disk(device_path.c_str());
+
+    MountUtilsLog("Unmount complete");
+
+    if (result != MOUNTUTILS_SUCCESS) {
+      switch (result) {
+        case MOUNTUTILS_ERROR_ACCESS_DENIED:
+          SetErrorMessage("Unmount failed, access denied");
+          break;
+        case MOUNTUTILS_ERROR_INVALID_DRIVE:
+          SetErrorMessage("Unmount failed, invalid drive");
+          break;
+        default:
+          SetErrorMessage("Unmount failed");
+          break;
+      }
+    }
+  }
+
+  void HandleOKCallback() {
+    Nan::HandleScope scope;
+    v8::Local<v8::Value> argv[] = { Nan::Null() };
+    callback->Call(1, argv);
+  }
+
+ private:
+  std::string device_path;
+};
+
+NAN_METHOD(unmountDisk) {
+  if (!info[1]->IsFunction()) {
+    return Nan::ThrowError("Callback must be a function");
+  }
+
+  if (!info[0]->IsString()) {
+    return Nan::ThrowError("Device must be a string");
+  }
+
+  Nan::Utf8String device(info[0]->ToString());
+  std::string device_path(*device);
+  Nan::Callback *callback = new Nan::Callback(info[1].As<v8::Function>());
+
+  Nan::AsyncQueueWorker(new UnmountWorker(callback, device_path));
+
+  info.GetReturnValue().SetUndefined();
+}

--- a/tests/mountutils.spec.js
+++ b/tests/mountutils.spec.js
@@ -28,18 +28,36 @@ describe('MountUtils', function() {
     context('missing / wrong arguments', function() {
 
       specify('throws on missing device', function() {
-        chai.expect( function() {
-          mountutils.unmountDisk( null, function() {})
-        }).to.throw( /must be a string/i )
-      })
+        chai.expect(function() {
+          mountutils.unmountDisk(null, function() {});
+        }).to.throw(/must be a string/i);
+      });
 
       specify('throws on missing callback', function() {
-        chai.expect( function() {
-          mountutils.unmountDisk( 'novalue' )
-        }).to.throw( /must be a function/i )
-      })
+        chai.expect(function() {
+          mountutils.unmountDisk('novalue');
+        }).to.throw(/must be a function/i);
+      });
 
-    })
+    });
+
+    context('invalid device', function() {
+
+      specify('device is a directory', function( done ) {
+        mountutils.unmountDisk( __dirname, function( error ) {
+          chai.expect(error.message).to.match(/Unmount failed/);
+          done();
+        });
+      });
+
+      specify('device is an empty string', function( done ) {
+        mountutils.unmountDisk( '', function( error ) {
+          chai.expect(error.message).to.match(/Unmount failed/);
+          done();
+        });
+      });
+
+    });
 
   });
 
@@ -52,18 +70,36 @@ describe('MountUtils', function() {
     context('missing / wrong arguments', function() {
 
       specify('throws on missing device', function() {
-        chai.expect( function() {
-          mountutils.eject( null, function() {})
-        }).to.throw( /must be a string/i )
-      })
+        chai.expect(function() {
+          mountutils.eject(null, function() {});
+        }).to.throw(/must be a string/i);
+      });
 
       specify('throws on missing callback', function() {
-        chai.expect( function() {
-          mountutils.eject( 'novalue' )
-        }).to.throw( /must be a function/i )
-      })
+        chai.expect(function() {
+          mountutils.eject('novalue');
+        }).to.throw(/must be a function/i);
+      });
 
-    })
+    });
+
+    context('invalid device', function() {
+
+      specify('device is a directory', function( done ) {
+        mountutils.eject( __dirname, function( error ) {
+          chai.expect(error.message).to.match(/Eject failed/);
+          done();
+        });
+      });
+
+      specify('device is an empty string', function( done ) {
+        mountutils.eject( '', function( error ) {
+          chai.expect(error.message).to.match(/Eject failed/);
+          done();
+        });
+      });
+
+    });
 
   });
 


### PR DESCRIPTION
**Changes:**

This implements an AsyncWorker for unmount & eject, so that we run
them in a libuv thread rather than blocking the main JS thread.

**TODO:**

- [ ] ~~Nicer errors (see `TODO` comments in `src/linux/functions.cpp`)~~
- [x] More tests to actually failure modes
- [x] Verify that this works manually on:
  - [x] MacOS
  - [x] Windows
  - [x] Linux

Change-Type: patch
Connects To: #11 