### PR TITLE
upgrade(package): Bump dependencies, remove gyp

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,11 +51,7 @@
 
 module.exports = require('bindings')({
   bindings: 'MountUtils',
-
-/* eslint-disable camelcase */
-
+  /* eslint-disable camelcase */
   module_root: __dirname
-
-/* eslint-enable camelcase */
-
+  /* eslint-enable camelcase */
 });

--- a/package.json
+++ b/package.json
@@ -32,11 +32,10 @@
   "author": "Juan Cruz Viotti <juan@resin.io>",
   "license": "Apache-2.0",
   "devDependencies": {
-    "chai": "^4.0.0",
-    "eslint": "^3.17.1",
+    "chai": "^4.0.2",
+    "eslint": "^4.0.0",
     "jsdoc-to-markdown": "^3.0.0",
-    "mocha": "^3.4.2",
-    "node-gyp": "^3.5.0"
+    "mocha": "^3.4.2"
   },
   "dependencies": {
     "bindings": "^1.2.1",


### PR DESCRIPTION
This bumps dependencies, and removes `node-gyp`,
as it ships with node, and doesn't need to be depended on explicitly.

Change-Type: patch