### PR TITLE
chore(appveyor): Use VS2015 base image

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,7 @@
 # appveyor file
 # http://www.appveyor.com/docs/appveyor-yml
+image:
+  - Visual Studio 2015
 
 init:
   - git config --global core.autocrlf input


### PR DESCRIPTION
As VS2013 doesn't support some C++ features used in newer
versions of Node / V8, the base image is updated to use VS2015.

Change-Type: patch
Connects To: resin-io-modules/drivelist#222